### PR TITLE
skbuild: skip_cmake=True unless sys.platform=linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,14 @@
+import sys
 from skbuild import setup
 from setuptools import find_packages
+
+# TODO enable cross-platform support for C/C++ extensions.
+skip_cmake = False if sys.platform in ['linux'] else True
 
 setup(
     packages=find_packages(where="python"),
     package_dir={"": "python"},
     include_package_data=True,
     package_data={"upsp.processing": ["templates/*.template"]},
+    skip_cmake=skip_cmake
 )


### PR DESCRIPTION
This is a bit of a hack but it allows us to build a "pure" Python package without the C/C++ extensions. There are some Linux-specific routines that must be handled carefully before re-enabling the CMake build for cross-platform support.