### PR TITLE
Add workflow to build docs and deploy to gh-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,62 @@
+name: Build docs + publish to GitHub Pages
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Sphinx docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[docs]
+
+      - name: Build documentation
+        run: |
+          cd docs/sphinx
+          make html
+
+      - name: Upload built docs artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: docs
+          path: ./docs/_build/
+
+  publish:
+    needs: [build]
+    runs-on: ubuntu-latest
+    # Upload for any push of tag starting with 'v'
+    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    # Upload for push to master
+    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/master')
+    steps:
+      - name: Download built docs artifact
+        uses: actions/download-artifact@v3
+        with:
+          # unpacks default artifact into dist/
+          # if `name: artifact` is omitted, the action will create extra parent dir
+          name: docs
+
+      - name: List contents
+        run: ls -R
+
+        # - name: Deploy to gh pages
+        #   uses: JamesIves/github-pages-deploy-action@v4.4.3
+        #   with:
+        #     branch: gh-pages
+        #     folder: ./docs/_build/html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,28 +35,21 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: docs
-          path: docs/sphinx/_build/
+          path: docs/sphinx/_build/html
 
   publish:
     needs: [build]
     runs-on: ubuntu-latest
     # Upload for any push of tag starting with 'v'
-    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    # Upload for push to master
-    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/master')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Download built docs artifact
         uses: actions/download-artifact@v3
         with:
-          # unpacks default artifact into dist/
-          # if `name: artifact` is omitted, the action will create extra parent dir
           name: docs
 
-      - name: List contents
-        run: ls -R
-
-        # - name: Deploy to gh pages
-        #   uses: JamesIves/github-pages-deploy-action@v4.4.3
-        #   with:
-        #     branch: gh-pages
-        #     folder: ./docs/_build/html
+      - name: Deploy to gh pages
+        uses: JamesIves/github-pages-deploy-action@v4.4.3
+        with:
+          branch: gh-pages
+          folder: .

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: docs
-          path: ./docs/_build/
+          path: docs/sphinx/_build/
 
   publish:
     needs: [build]


### PR DESCRIPTION
Build docs on any pull request, merge into master, or manual trigger. Upload to gh-pages on tag.

There are some warnings/errors in the docs build that currently don't cause the job to fail. We may want to clean those up and enable "nit-picky" builds at some point (I could do it here I guess).